### PR TITLE
API キーを job 単位で指定するように変更、onStart で指定した際に通知が飛ばないエラーを修正

### DIFF
--- a/DatadogEventNotification.groovy
+++ b/DatadogEventNotification.groovy
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode
 class DEFAULTS {
     static String DATADOG_EVENT_URL = "https://app.datadoghq.com/api/v1/events?api_key="
     static String SUBJECT_LINE='Rundeck JOB: ${job.status} [${job.project}] \"${job.name}\" run by ${job.user} (#${job.execid})'
+    static String API_KEY='Your Datadog API Key'
 }
 
 /**
@@ -50,6 +51,9 @@ def alertInfo(binding) {
       break
     case "failed" :
       alert_info = "error"
+      break
+    default:
+      alert_info = "info"
       break
   }
    return alert_info
@@ -101,8 +105,8 @@ rundeckPlugin(NotificationPlugin){
     title="DataDog_Event"
     description="Create a Trigger event."
     configuration{
-        subject title:"Subject", description:"Incident subject line. Can contain \${job.status}, \${job.project}, \${job.name}, \${job.group}, \${job.user}, \${job.execid}", defaultValue:DEFAULTS.SUBJECT_LINE,required:true
-        api_key title:"API Key", description:"Datadog API key", scope:"Project"
+        subject title:"Subject", description:"Incident subject line. Can contain \${job.status}, \${job.project}, \${job.name}, \${job.group}, \${job.user}, \${job.execid}", defaultValue:DEFAULTS.SUBJECT_LINE, required:true
+        api_key title:"API Key", description:"Datadog API key", defaultValue:DEFAULTS.API_KEY, required:true
     }
     onstart { Map execution, Map configuration ->
         triggerEvent(execution, configuration)

--- a/README.md
+++ b/README.md
@@ -14,16 +14,3 @@ The plugin requires one configuration entry.
 
 * subject: This string will be set as the description for the generated incident.
 * api_key: This is the API Key to your Datadog API.
-
-Configure the api_key in your project configuration by
-adding an entry like so: $RDECK_BASE/projects/{project}/etc/project.properties
-
-```sh
-project.plugin.Notification.DatadogEventNotification.api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-```
-
-Or configure it at the instance level: $RDECK_BASE/etc/framework.properties
-
-```sh
-framework.plugin.Notification.DatadogEventNotification.api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-```


### PR DESCRIPTION
- API キーを job 単位で指定するように変更
- onStart で指定した際に通知が飛ばないエラーを修正
